### PR TITLE
Enabling building on tags in Circle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,14 @@ workflows:
   version: 2
   test-and-publish:
     jobs:
-      - test-py27
-      - test-py36
+      - test-py27:
+          filters:
+            tags:
+              only: /.*/
+      - test-py36:
+          filters:
+            tags:
+              only: /.*/
       - publish:
           requires:
             - test-py27


### PR DESCRIPTION
If you want tags to build in CircleCI 2.0 with workflows, you have to explicitly enable it on every build in the workflow.

@ustudio/reviewers Please review