### PR TITLE
Enable Stopping IOLoop Without Needing a Server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 
 setup(name="ustack-tornado-shutdown",
-      version="0.1.0",
+      version="0.2.0",
       description="Library for gracefully terminating a Tornado server on SIGTERM",
       url="https://github.com/ustudio/ustack-tornado-shutdown",
       packages=["ustack_tornado_shutdown"],

--- a/tests/test_tornado_shutdown.py
+++ b/tests/test_tornado_shutdown.py
@@ -35,3 +35,22 @@ class TestTornadoShutdown(unittest.TestCase):
         mock_ioloop.call_later.call_args[0][1]()
 
         mock_ioloop.stop.assert_called_once_with()
+
+    @mock.patch("signal.signal")
+    def test_on_sigterm_shuts_down_ioloop_when_server_is_none(
+            self, mock_signal):
+        mock_ioloop = mock.Mock()
+
+        tornado_shutdown.on_sigterm(None, mock_ioloop)
+
+        mock_signal.assert_called_once_with(signal.SIGTERM, mock.ANY)
+
+        # Simulate the OS calling the signal handler
+        mock_signal.call_args[0][1]("ignored", "also-ignored")
+
+        mock_ioloop.add_callback_from_signal.assert_called_once_with(mock.ANY)
+
+        # Simulate the IO loop calling the callback
+        mock_ioloop.add_callback_from_signal.call_args[0][0]()
+
+        mock_ioloop.stop.assert_called_once_with()

--- a/ustack_tornado_shutdown/tornado_shutdown.py
+++ b/ustack_tornado_shutdown/tornado_shutdown.py
@@ -15,7 +15,10 @@ def handle_signal(server, ioloop, signum, frame):
         server.stop()
         ioloop.call_later(2, stop_ioloop)
 
-    ioloop.add_callback_from_signal(stop_server)
+    if server is None:
+        ioloop.add_callback_from_signal(stop_ioloop)
+    else:
+        ioloop.add_callback_from_signal(stop_server)
 
 
 def on_sigterm(server, ioloop):

--- a/ustack_tornado_shutdown/tornado_shutdown.py
+++ b/ustack_tornado_shutdown/tornado_shutdown.py
@@ -22,4 +22,12 @@ def handle_signal(server, ioloop, signum, frame):
 
 
 def on_sigterm(server, ioloop):
+    """Shut down server and ioloop when SIGTERM signal is received.
+
+    The server may be None, in which case only the ioloop is stopped on SIGTERM.
+
+    If the server is not None, it will be stopped, first, and then the ioloop will be stopped two
+    seconds later.
+    """
+
     signal.signal(signal.SIGTERM, functools.partial(handle_signal, server, ioloop))


### PR DESCRIPTION
This PR lets you pass `None` as the server parameter when calling `on_sigterm`, so that projects that have an `IOLoop` but no `HTTPServer` can use this library to gracefully shut down.

@ustudio/reviewers Please review