### PR TITLE
Use cimg/python:3.9 to Push to PyPI, to Use Cryptography Wheel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
 
   publish:
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Newer versions of Cryptography need the Rust compiler installed to build from source. By switching to the latest CircleCI convenience image for Python, we can install the "wheel" of the Cryptography Python library, and thus not need Rust installed.

@ustudio/reviewers Please review